### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ ENV REALOPINSIGHT_DATA_DIR /data
 WORKDIR /app
 COPY --from=builder /app/dist .
 RUN apt update && \
-    apt install -y libsqlite3-0 graphviz sudo && \
+    apt install --no-install-recommends -y libsqlite3-0 graphviz sudo && \
     (id ${APP_USER} || useradd ${APP_USER} -u $APP_USER_UID) && \
     echo "${APP_USER} ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
     mkdir -p /app/www/run /data && \
-    chown -R ${APP_USER}:${APP_USER} /app /data
+    chown -R ${APP_USER}:${APP_USER} /app /data && rm -rf /var/lib/apt/lists/*;
 VOLUME ["/data"]
 USER ${APP_USER}
 ENTRYPOINT ["/app/container-entrypoint.sh"]


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added the `--no-install-recommends` to with apt-get in order to not install unnecessary packages and reduce the image size.
* I added `rm -rf /var/lib/apt/lists/*` after `apt-get install` which removes unnecessary files and reduces the size of the image.


Impact on the image size:
* Image size before repair: 809 MB
* Image size after repair: 769.99 MB
* Difference: 39 MB (4.82%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,