### PR TITLE
Improve handling of nonexistent user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 COPY --from=builder /app/dist .
 RUN apt update && \
     apt install --no-install-recommends -y libsqlite3-0 graphviz sudo && \
-    (id ${APP_USER} || useradd ${APP_USER} -u $APP_USER_UID) && \
+    (id ${APP_USER} 2>/dev/null || (echo creating user ${APP_USER}=$APP_USER_UID && useradd ${APP_USER} -u $APP_USER_UID)) && \
     echo "${APP_USER} ALL=NOPASSWD: ALL" > /etc/sudoers.d/user && \
     mkdir -p /app/www/run /data && \
     chown -R ${APP_USER}:${APP_USER} /app /data && rm -rf /var/lib/apt/lists/*;


### PR DESCRIPTION
The red text here: https://github.com/check-spelling/realopinsight/actions/runs/5703821340/job/15456837481#step:3:1205
> id: 'realopinsight': no such user

is misleading -- it felt like an error and it was confusing that the build didn't stop.


