### PR TITLE
Restrict github permissions for workflow

### DIFF
--- a/.github/workflows/build-image-on-pr.yml
+++ b/.github/workflows/build-image-on-pr.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+
     concurrency:
       group: image-pr-${{ github.event.pull_request.number }}
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+
     concurrency:
       group: image-${{ github.ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+
     concurrency:
       group: ci-${{ github.ref }}
 


### PR DESCRIPTION
This is a belt-and-suspenders PR.

Afaict, none of these workflows need any permissions beyond `contents: read` (some need `secrets.*` and that's a story for another PR).